### PR TITLE
feat: add use command :Miser format 

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ No LSP config blocks. No formatter autocmds. Just declare your tools.
 | `:Miser status` | Open a status panel showing tools, LSPs, and formatters |
 | `:Miser install` | Run `mise install` and re-activate LSPs and formatters |
 | `:Miser run <task>` | Run a mise task via your configured `task_runner` |
+| `:Miser format` | Run formatter on-demand in current buffer |
 
 The status panel supports:
 - `q` / `<Esc>` to close

--- a/lua/miser/format.lua
+++ b/lua/miser/format.lua
@@ -5,7 +5,7 @@ local M = {}
 -- Map of filetype -> formatter cmd, built once from mise tools + registry
 M._formatters = {}
 
-function M.setup(tools)
+function M.setup(tools, auto_format)
   M._formatters = {}
 
   local claimed = {}
@@ -22,7 +22,7 @@ function M.setup(tools)
     end
   end
 
-  if not vim.tbl_isempty(M._formatters) then
+  if auto_format and not vim.tbl_isempty(M._formatters) then
     M._create_autocmd()
   end
 
@@ -35,42 +35,50 @@ function M._create_autocmd()
   vim.api.nvim_create_autocmd("BufWritePost", {
     group = group,
     callback = function(ev)
-      local buf = ev.buf
-      if vim.b[buf]._miser_formatting then
-        return
-      end
-
-      local ft = vim.bo[buf].filetype
-      local cmd = M._formatters[ft]
-      if not cmd then
-        return
-      end
-
-      local filepath = vim.api.nvim_buf_get_name(buf)
-      if filepath == "" then
-        return
-      end
-
-      vim.b[buf]._miser_formatting = true
-
-      local full_cmd = vim.list_extend({}, cmd)
-      table.insert(full_cmd, filepath)
-
-      vim.system(full_cmd, { text = true }, function(result)
-        vim.schedule(function()
-          vim.b[buf]._miser_formatting = false
-          if result.code == 0 then
-            vim.cmd("checktime")
-          else
-            vim.notify(
-              "miser: format failed (" .. table.concat(cmd, " ") .. ")\n" .. (result.stderr or ""),
-              vim.log.levels.WARN
-            )
-          end
-        end)
-      end)
+      M.run(ev.buf)
     end,
   })
+end
+
+function M.run(buf, opts)
+  opts = opts or {}
+
+  if vim.b[buf]._miser_formatting then
+    return
+  end
+
+  local ft = vim.bo[buf].filetype
+  local cmd = M._formatters[ft]
+  if not cmd then
+    if opts.notify then
+      vim.notify("miser: no formatter registered for filetype '" .. ft .. "'", vim.log.levels.INFO)
+    end
+    return
+  end
+
+  local filepath = vim.api.nvim_buf_get_name(buf)
+  if filepath == "" then
+    return
+  end
+
+  vim.b[buf]._miser_formatting = true
+
+  local full_cmd = vim.list_extend({}, cmd)
+  table.insert(full_cmd, filepath)
+
+  vim.system(full_cmd, { text = true }, function(result)
+    vim.schedule(function()
+      vim.b[buf]._miser_formatting = false
+      if result.code == 0 then
+        vim.cmd("checktime")
+      else
+        vim.notify(
+          "miser: format failed (" .. table.concat(cmd, " ") .. ")\n" .. (result.stderr or ""),
+          vim.log.levels.WARN
+        )
+      end
+    end)
+  end)
 end
 
 return M

--- a/lua/miser/init.lua
+++ b/lua/miser/init.lua
@@ -36,9 +36,8 @@ function M.activate(opts)
   if opts.auto_lsp then
     M._state.enabled_lsps = require("miser.lsp").setup(tools)
   end
-  if opts.auto_format then
-    M._state.formatters = require("miser.format").setup(tools)
-  end
+
+  M._state.formatters = require("miser.format").setup(tools, opts.auto_format)
 end
 
 function M.show_status()
@@ -236,15 +235,24 @@ function M.setup(opts)
       end)
     elseif subcmd == "status" then
       M.show_status()
+    elseif subcmd == "format" then
+      local bufnr = vim.api.nvim_get_current_buf()
+      if vim.bo[bufnr].modified then
+        vim.cmd("write")
+      end
+      require("miser.format").run(bufnr, { notify = true })
     else
-      vim.notify("miser: unknown command '" .. (subcmd or "") .. "'\nUsage: Miser status | run <task> | install | trust", vim.log.levels.WARN)
+      vim.notify(
+        "miser: unknown command '" .. (subcmd or "") .. "'\nUsage: Miser status | run <task> | install | trust | format",
+        vim.log.levels.WARN
+      )
     end
   end, {
     nargs = "+",
     complete = function(_, line)
       local parts = vim.split(line, "%s+")
       if #parts <= 2 then
-        return { "install", "run", "status", "trust" }
+        return { "install", "run", "status", "trust", "format" }
       end
       return {}
     end,


### PR DESCRIPTION
This PR introduces the ability to run formatters on-demand, even if `auto_format` is set to `false`. 
The formatting logic was extracted from the autocmd callback and moved into `miser.format.run()`.
This function is now shared between the autocmds and the new `:Miser format` user command.