### PR TITLE
feat: add Miser format cmd (#3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ Tools can have both:
 | gofumpt | | gofumpt -w |
 | black | | black |
 | shfmt | | shfmt -w |
+| tombi | tombi | |
 
 ### Extending the registry
 

--- a/lua/miser/registry/init.lua
+++ b/lua/miser/registry/init.lua
@@ -20,6 +20,7 @@ register(require("miser.registry.ruby_lsp"))
 register(require("miser.registry.ruff"))
 register(require("miser.registry.shfmt"))
 register(require("miser.registry.stylua"))
+register(require("miser.registry.tombi"))
 register(require("miser.registry.typescript_language_server"))
 register(require("miser.registry.zls"))
 

--- a/lua/miser/registry/tombi.lua
+++ b/lua/miser/registry/tombi.lua
@@ -1,0 +1,3 @@
+return {
+  ["tombi"] = { lsp = "tombi" },
+}


### PR DESCRIPTION
This PR adds the `tombi` LSP for `.toml` files to the registry.